### PR TITLE
Tests and type annotations

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "printWidth": 120,
+  "arrowParens": "avoid",
+  "semi": true,
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "useTabs": false
+}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 An easy-to-use library to make your life easier when working with random numbers or random choices in javascript.
 
 # Table of contents
+
 - [Installation & Usage](#installation--usage)
 - [Tests](#tests)
 - [Docs](#docs)
@@ -24,21 +25,22 @@ npm i vrandom
 
 Import the package where you need it (both commonjs and module syntax supported)
 
-```
-import vrandom from "vrandom"
+```js
+import vrandom from "vrandom";
 ```
 
-or 
+or
 
-```
-const vrandom = require("vrandom")
+```js
+const vrandom = require("vrandom");
 ```
 
 Use the function you need by accessing it through the vrandom object
 
+```js
+vrandom.flip();
 ```
-vrandom.flip()
-```
+
 # Tests
 
 The library is fully tested. If you are contributing and you are creating a new feature please add tests to it.
@@ -49,10 +51,13 @@ If you want to see the tests running:
 
 1. Clone the repo locally
 2. Install dependencies
+
 ```
 npm i
 ```
+
 3. run tests
+
 ```
 npm t
 ```
@@ -65,13 +70,12 @@ npm t
 - [pick](#pick)
 - [shuffle](#shuffle)
 
-
 ## flip
 
 Usage:
 
-```
-vrandom.flip()
+```js
+vrandom.flip();
 
 // possible output: true
 ```
@@ -82,8 +86,8 @@ It doesn't take any arguments, it returns true 50% of the time and false 50% of 
 
 Usage:
 
-```
-vrandom.int(min, max)
+```js
+vrandom.int(min, max);
 ```
 
 It takes two arguments, min and max
@@ -94,28 +98,27 @@ It returns a random integer between min and max - min INCLUDED, max EXCLUDED
 
 Example:
 
-```
-vrandom.int(1, 10)
+```js
+vrandom.int(1, 10);
 
-// possile output: 4
+// possible output: 4
 ```
 
 Will return a random integer between 1 (included) and 10 (not-included)
 
-## float 
+## float
 
 Usage:
 
+```js
+vrandom.float(min, max, decimals);
 ```
-vrandom.float(min,max, decimals)
-```
-
 
 It takes 2 arguments, plus 1 optional argument if only two arguments are provided the third argument defaults to 2.
 
 The first and second arguments have to be numbers (floats or ints) the third argument has to be an integer.
 
-The function will return a random floating point number between min and max - min INCLUDED, max EXCLUDED. The returned floating point number will have a maximum of 2 decimal places if no third argument is specified. 
+The function will return a random floating point number between min and max - min INCLUDED, max EXCLUDED. The returned floating point number will have a maximum of 2 decimal places if no third argument is specified.
 
 If a third argument is passed, that will be the maximum number of decimals that the returned floating point number will have. Maximum of 15.
 
@@ -125,8 +128,8 @@ The function will return an error if: less than 2 arguments are passed, the thir
 
 Example:
 
-```
-vrandom.float(0, 10, 5)
+```js
+vrandom.float(0, 10, 5);
 // possible output: 0.47185
 ```
 
@@ -134,8 +137,8 @@ vrandom.float(0, 10, 5)
 
 Usage:
 
-```
-vrandom.pick(array)
+```js
+vrandom.pick(array);
 ```
 
 It takes one argument, and it HAS to be an array, if not it will throw an error.
@@ -144,34 +147,34 @@ It will return a random element from that array.
 
 Example:
 
-```
-const arr = [1, 2, 3, 4, "hello", "world", true, false]
-vrandom.pick(arr)
+```js
+const arr = [1, 2, 3, 4, "hello", "world", true, false];
+vrandom.pick(arr);
 
 // possible output: 1
 ```
 
 Will return a random element from the array 'arr'
 
-## shuffle 
+## shuffle
 
 Usage:
 
+```js
+vrandom.shuffle(array);
 ```
-vrandom.shuffle(array)
-```
+
 It takes one argument, and it HAS to be an array.
 
 It will return a new array with the same elements as the provided array, but in (possibly) a different order, every element is shuffled and is assigned a new position (the initial position of the element is included in the possible positions where the element ends up).
 
 Example:
 
-```
-const arr = [1, 2, "hello", "world", true, false]
-vrandom.shuffle(arr)
+```js
+const arr = [1, 2, "hello", "world", true, false];
+vrandom.shuffle(arr);
 
 // possible output: [1, "hello", true, false, 2, "world"]
-
 ```
 
 # Creators & Contributors

--- a/lib/flip.js
+++ b/lib/flip.js
@@ -1,5 +1,5 @@
 const flip = () => {
   return Math.random() > 0.5;
-}
+};
 
 module.exports = flip;

--- a/lib/float.js
+++ b/lib/float.js
@@ -1,23 +1,21 @@
 const float = (min, max, decimals = 2) => {
-	if (!Number.isFinite(min) || !Number.isFinite(max)) {
-		throw new TypeError('min and max must be numbers')
-	}
+  if (!Number.isFinite(min) || !Number.isFinite(max)) {
+    throw new TypeError("min and max must be numbers");
+  }
 
-	if (!Number.isInteger(decimals)) {
-		throw new TypeError('decimals must be an integer')
-	}
+  if (!Number.isInteger(decimals)) {
+    throw new TypeError("decimals must be an integer");
+  }
 
-	if (decimals < 0 || decimals > 15) {
-		throw new RangeError('decimals must be between 0 and 15')
-	}
+  if (decimals < 0 || decimals > 15) {
+    throw new RangeError("decimals must be between 0 and 15");
+  }
 
-	if (min >= max) {
-		throw new Error(
-			'first arguments needs to be smaller than second argument'
-		)
-	}
+  if (min >= max) {
+    throw new Error("first arguments needs to be smaller than second argument");
+  }
 
-	return parseFloat((Math.random() * (max - min) + min).toFixed(decimals))
-}
+  return parseFloat((Math.random() * (max - min) + min).toFixed(decimals));
+};
 
 module.exports = float;

--- a/lib/float.js
+++ b/lib/float.js
@@ -1,3 +1,9 @@
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} decimals
+ * @throws if any of `min`, `max` or `decimals` are invalid.
+ */
 const float = (min, max, decimals = 2) => {
   if (!Number.isFinite(min) || !Number.isFinite(max)) {
     throw new TypeError("min and max must be numbers");

--- a/lib/int.js
+++ b/lib/int.js
@@ -1,3 +1,8 @@
+/**
+ * @param {number} min
+ * @param {number} max
+ * @throws if `min` and/or `max` are invalid.
+ */
 const int = (min, max) => {
   if (!Number.isInteger(min) || !Number.isInteger(max)) {
     throw new TypeError("Both arguments need to be integers");

--- a/lib/pick.js
+++ b/lib/pick.js
@@ -1,6 +1,6 @@
 const int = require("./int.js");
 
-const pick = (array) => {
+const pick = array => {
   if (!Array.isArray(array)) {
     throw new TypeError(`${array} is not an Array`);
   }

--- a/lib/pick.js
+++ b/lib/pick.js
@@ -1,5 +1,10 @@
 const int = require("./int.js");
 
+/**
+ * @template {unknown} T
+ * @param {T[]} array
+ * @throws if `array` is not an array.
+ */
 const pick = array => {
   if (!Array.isArray(array)) {
     throw new TypeError(`${array} is not an Array`);

--- a/lib/shuffle.js
+++ b/lib/shuffle.js
@@ -1,3 +1,8 @@
+/**
+ * Makes a shallow copy of `array` to prevent the argument from being mutated.
+ * @template {unknown} T
+ * @param {T[]} array
+ */
 const shuffle = ([...array]) => {
   let currentIndex = array.length,
     temporaryValue,

--- a/lib/shuffle.js
+++ b/lib/shuffle.js
@@ -1,4 +1,4 @@
-const shuffle = (array) => {
+const shuffle = ([...array]) => {
   let currentIndex = array.length,
     temporaryValue,
     randomIndex;

--- a/tests/flip.test.js
+++ b/tests/flip.test.js
@@ -4,3 +4,34 @@ it("returns a boolean", () => {
   const actual = flip();
   expect(typeof actual).toBe("boolean");
 });
+
+it.each([
+  [false, 0],
+  [false, 0.000001],
+  [false, 0.1],
+  [false, 0.12],
+  [false, 0.2],
+  [false, 0.245],
+  [false, 0.3],
+  [false, 0.30159],
+  [false, 0.4],
+  [false, 0.437],
+  [false, 0.5],
+  [true, 0.5000001],
+  [true, 0.50956],
+  [true, 0.6],
+  [true, 0.612416],
+  [true, 0.7],
+  [true, 0.723556956],
+  [true, 0.8],
+  [true, 0.8235235],
+  [true, 0.9000004],
+  [true, 0.9999999999999999],
+])("flip() should return %s when Math.random returns %f", (expected, mockValue) => {
+  jest.spyOn(Math, "random").mockReturnValueOnce(mockValue);
+
+  const actual = flip();
+  expect(actual).toBe(expected);
+
+  Math.random.mockRestore();
+});

--- a/tests/float.test.js
+++ b/tests/float.test.js
@@ -1,6 +1,6 @@
 const float = require("../lib/float.js");
 
-const decimalCount = (num) => {
+const decimalCount = num => {
   const numStr = num.toString();
 
   if (numStr.includes(".")) {
@@ -14,6 +14,28 @@ describe("float", () => {
   it("should return a number", () => {
     expect(typeof float(0, 1)).toBe("number");
   });
+
+  it.each([
+    { mockValue: 0.5, min: 0, max: 1, decimals: 5, expected: 0.5 },
+    { mockValue: 0.45, min: 5, max: 10, decimals: 4, expected: 7.25 },
+    { mockValue: 0.912, min: 78, max: 120, decimals: 12, expected: 116.304 },
+    { mockValue: 0.004, min: 13, max: 14, decimals: 2, expected: 13 },
+    { mockValue: 0.356, min: 32, max: 53, decimals: 1, expected: 39.5 },
+    { mockValue: 0.9124, min: 10_005, max: 54_505_502, decimals: 3, expected: 49_731_696.463 },
+    { mockValue: 0.671, min: 51, max: 98, decimals: undefined, expected: 82.54 },
+  ])(
+    "float($min, $max, $decimals) should return $expected when Math.random returns $mockValue",
+    ({ mockValue, min, max, decimals, expected }) => {
+      jest.spyOn(Math, "random").mockReturnValueOnce(mockValue);
+
+      const actual = float(min, max, decimals);
+      // `toBeCloseTo` matcher is normally appropriate for comparing floats (as it handles floating point imprecision),
+      // but we might be alright here to just use `toBe`.
+      expect(actual).toBe(expected);
+
+      Math.random.mockRestore();
+    },
+  );
 
   it("should return a number between min and max", () => {
     expect(float(0, 1)).toBeGreaterThanOrEqual(0);

--- a/tests/int.test.js
+++ b/tests/int.test.js
@@ -10,19 +10,34 @@ describe("int", () => {
     expect(actual).toBeLessThan(max);
   });
 
+  it.each([
+    { mockValue: 0.412, min: 0, max: 3, expected: 1 },
+    { mockValue: 0.15029, min: 416, max: 5_905, expected: 1_240 },
+    { mockValue: 0.5602, min: 15, max: 67, expected: 44 },
+    { mockValue: 0.1294, min: 1502, max: 53_047, expected: 8_171 },
+    { mockValue: 0.37656, min: 16, max: 23, expected: 18 },
+    { mockValue: 0.9713, min: 160_590, max: 1_250_858, expected: 1_219_567 },
+  ])(
+    "int($min, $max) should return $expected when Math.random returns $mockValue",
+    ({ mockValue, min, max, decimals, expected }) => {
+      jest.spyOn(Math, "random").mockReturnValueOnce(mockValue);
+
+      const actual = int(min, max, decimals);
+      expect(actual).toBe(expected);
+
+      Math.random.mockRestore();
+    },
+  );
+
   it("throws an error if arguments are not both integers", () => {
     const min = "hello";
     const max = 3;
-    expect(() => int(min, max)).toThrow(
-      TypeError("Both arguments need to be integers")
-    );
+    expect(() => int(min, max)).toThrow(TypeError("Both arguments need to be integers"));
   });
 
   it("throws an error if min is greater or equal to max", () => {
     const min = 10;
     const max = 1;
-    expect(() => int(min, max)).toThrow(
-      Error("first argument needs to be smaller than second argument")
-    );
+    expect(() => int(min, max)).toThrow(Error("first argument needs to be smaller than second argument"));
   });
 });

--- a/tests/pick.test.js
+++ b/tests/pick.test.js
@@ -1,6 +1,21 @@
 const pick = require("../lib/pick.js");
 
 describe("pick", () => {
+  it.each([
+    { items: [1, 2, 3, 6, 5, "hello", true, false], mockValue: 0.5, expected: 5 },
+    { items: [1, "bye", false, 45n], mockValue: 0.3124, expected: "bye" },
+    { items: [Infinity, 0, -Infinity], mockValue: 0.909309, expected: -Infinity },
+    { items: ["my", NaN, "is", 156, "a", "b", "e", 25n, "t", "g", "AAAAA"], mockValue: 0.000152, expected: "my" },
+    { items: ["only"], mockValue: 0.01, expected: "only" },
+  ])("pick($items) should return '$expected' when Math.random returns $mockValue", ({ items, mockValue, expected }) => {
+    jest.spyOn(Math, "random").mockReturnValueOnce(mockValue);
+
+    const actual = pick(items);
+    expect(actual).toBe(expected);
+
+    Math.random.mockRestore();
+  });
+
   it("returns a random item from an array", () => {
     const arr = [1, 2, 3, 4, 5, "hello", true, false];
     const actual = pick(arr);

--- a/tests/shuffle.test.js
+++ b/tests/shuffle.test.js
@@ -8,3 +8,34 @@ test("shuffle array", () => {
 
   expect(result.length).toBe(array.length);
 });
+
+it.each([
+  // Unfortunately, JS doesn't allow for seeding Math.random. That might change with proposals like
+  // https://www.proposals.es/proposals/Math.seededRandoms() in the future.
+  // For now, can mock Math.random -- unless there's a better, less tedious way.
+  { array: [1, 2, 3, 4, 5], mockValues: [0.9, 0.9, 0.9, 0.9, 0.9], expected: [1, 2, 3, 4, 5] },
+  { array: [1, true, 3], mockValues: [0.0105, 0.9595, 0.42], expected: [3, true, 1] },
+  { array: [1], mockValues: [0.99891], expected: [1] },
+  { array: [1], mockValues: [0.0021], expected: [1] },
+  { array: ["a", false], mockValues: [0.0021, 0.03683], expected: [false, "a"] },
+  {
+    array: ["a", "b", "c", "d", "e", "f"],
+    mockValues: [0.4, 0.0003, 0.999, 0.9451, 0.9, 0.9],
+    expected: ["e", "b", "f", "d", "a", "c"],
+  },
+])(
+  "shuffle($array) should return $expected when Math.random returns $mockValues individually",
+  ({ array, mockValues, expected }) => {
+    jest.spyOn(Math, "random");
+
+    mockValues.forEach(mockValue => {
+      Math.random.mockReturnValueOnce(mockValue);
+    });
+
+    const actual = shuffle(array);
+
+    expect(actual).toStrictEqual(expected);
+
+    Math.random.mockRestore();
+  },
+);


### PR DESCRIPTION
Thanks for writing this package.

- Adding some more tests to the existing test suites.
- Adding some basic type annotations via JSDoc comments. This should help IDEs and users understand what types those functions take in and give back.
- Adding a Prettier config file, although it might be better to actually run Prettier (and ESLint too) as part of the GitHub Actions workflow. Just to enforce consistent formatting across the project (as the config file I've added will do nothing on machines where Prettier isn't installed/enabled).
- Updating `shuffle` so that it makes a shallow copy of its `array` argument before it begins shuffling. I think this is in line with what the docs currently mention.
- Adding `js` to the code blocks in the README. Shouldn't do much other than provide syntax highlighting on platforms that support it.

----

Should probably put the below in an issue instead of this PR, but it's a minor point. Might be worth checking the docs for `float`. If I'm reading correctly, docs suggest `max` is exclusive:

https://github.com/ValerioCipolla/vrandom/blob/f37b299fa6479464bb2a243d2905ea93613e8d4e/README.md?plain=1#L118

but the existing test suggests `min >= return value <= max`:

https://github.com/ValerioCipolla/vrandom/blob/f37b299fa6479464bb2a243d2905ea93613e8d4e/tests/float.test.js#L20

`float`'s implementation uses `toFixed` which can round up.

```js
(0.125).toFixed(2)
// '0.13'

(0.121).toFixed(2)
// '0.12'

(0.129).toFixed(2)
// '0.13'
````